### PR TITLE
fix: value boolean comparison

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const stitchtail = <Props = null, Propless = null>({ base, variants, compounds }
 				Object.entries(props).forEach(([key, value]) => {
 					const vari: unknown = variants as unknown;
 
-					if (typeof variants[key as keyof typeof variants] === "string") {
+					if (typeof variants[key as keyof typeof variants] === "string" && value === true) {
 						classes.push(...(variants[key as keyof typeof variants] as string).split(" "));
 					} else if (typeof variants[key as keyof typeof variants] === "object" && variants[key as keyof typeof variants][value as keyof { [key in keyof typeof vari]: typeof variants[key] }]) {
 						classes.push(...(variants[key as keyof typeof variants][value as keyof { [key in keyof typeof vari]: typeof variants[key] }] as string).split(" "));


### PR DESCRIPTION
Fixes: #1 

Adds a guard to check if value is set to true, this ensures that the property being passed is not only "set", but also `true`; further testing for other uses cases maybe necessary but works for most use cases.